### PR TITLE
Expand EssentialCore with commands and listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # EssentialCore
+
+EssentialCore erweitert die Grundfunktionen von [EssentialsX](https://essentialsx.net/) in einem kompakten Plugin. Das Projekt verwendet Maven und ist für Minecraft Versionen 1.21 bis 1.21.7 ausgelegt.
+
+## Features
+
+- `/heal` – regeneriert Gesundheit und Hunger
+- `/feed` – füllt den Hungerbalken auf
+- `/sethome` – speichert deinen aktuellen Standort
+- `/home` – teleportiert dich zu deinem Zuhause
+- `/setspawn` – legt den globalen Spawnpunkt fest
+- `/spawn` – teleportiert zum Spawnpunkt
+
+Das Plugin nutzt eine klare Ordnerstruktur mit `commands` und `listeners`, sodass du es leicht erweitern kannst.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.devvoxel</groupId>
+    <artifactId>EssentialCore</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>EssentialCore</name>
+    <description>Minimal Essentials-like plugin</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/net/devvoxel/essentialcore/EssentialCore.java
+++ b/src/main/java/net/devvoxel/essentialcore/EssentialCore.java
@@ -1,0 +1,49 @@
+package net.devvoxel.essentialcore;
+
+import net.devvoxel.essentialcore.commands.*;
+import net.devvoxel.essentialcore.listeners.PlayerJoinListener;
+import org.bukkit.Location;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class EssentialCore extends JavaPlugin {
+
+    private final Map<UUID, Location> homes = new HashMap<>();
+    private Location spawn;
+
+    public Map<UUID, Location> getHomes() {
+        return homes;
+    }
+
+    public Location getSpawn() {
+        return spawn;
+    }
+
+    public void setSpawn(Location spawn) {
+        this.spawn = spawn;
+    }
+
+    @Override
+    public void onEnable() {
+        getLogger().info("EssentialCore enabled!");
+
+        // register commands
+        getCommand("heal").setExecutor(new HealCommand());
+        getCommand("feed").setExecutor(new FeedCommand());
+        getCommand("sethome").setExecutor(new SetHomeCommand(this));
+        getCommand("home").setExecutor(new HomeCommand(this));
+        getCommand("setspawn").setExecutor(new SetSpawnCommand(this));
+        getCommand("spawn").setExecutor(new SpawnCommand(this));
+
+        // register listeners
+        getServer().getPluginManager().registerEvents(new PlayerJoinListener(this), this);
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("EssentialCore disabled!");
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/FeedCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/FeedCommand.java
@@ -1,0 +1,21 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class FeedCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        player.setFoodLevel(20);
+        player.sendMessage(ChatColor.GREEN + "You have been fed.");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/HealCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/HealCommand.java
@@ -1,0 +1,22 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class HealCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        player.setHealth(player.getMaxHealth());
+        player.setFoodLevel(20);
+        player.sendMessage(ChatColor.GREEN + "You have been healed.");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/HomeCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/HomeCommand.java
@@ -1,0 +1,35 @@
+package net.devvoxel.essentialcore.commands;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class HomeCommand implements CommandExecutor {
+
+    private final EssentialCore plugin;
+
+    public HomeCommand(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        Location loc = plugin.getHomes().get(player.getUniqueId());
+        if (loc != null) {
+            player.teleport(loc);
+            player.sendMessage(ChatColor.YELLOW + "Teleported to home.");
+        } else {
+            player.sendMessage(ChatColor.RED + "No home set.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/SetHomeCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/SetHomeCommand.java
@@ -1,0 +1,31 @@
+package net.devvoxel.essentialcore.commands;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SetHomeCommand implements CommandExecutor {
+
+    private final EssentialCore plugin;
+
+    public SetHomeCommand(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        Location loc = player.getLocation();
+        plugin.getHomes().put(player.getUniqueId(), loc);
+        player.sendMessage(ChatColor.YELLOW + "Home set.");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/SetSpawnCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/SetSpawnCommand.java
@@ -1,0 +1,31 @@
+package net.devvoxel.essentialcore.commands;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SetSpawnCommand implements CommandExecutor {
+
+    private final EssentialCore plugin;
+
+    public SetSpawnCommand(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        Location loc = player.getLocation();
+        plugin.setSpawn(loc);
+        player.sendMessage(ChatColor.YELLOW + "Spawn location set.");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/SpawnCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/SpawnCommand.java
@@ -1,0 +1,35 @@
+package net.devvoxel.essentialcore.commands;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SpawnCommand implements CommandExecutor {
+
+    private final EssentialCore plugin;
+
+    public SpawnCommand(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        Location loc = plugin.getSpawn();
+        if (loc != null) {
+            player.teleport(loc);
+            player.sendMessage(ChatColor.YELLOW + "Teleported to spawn.");
+        } else {
+            player.sendMessage(ChatColor.RED + "Spawn not set.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/listeners/PlayerJoinListener.java
+++ b/src/main/java/net/devvoxel/essentialcore/listeners/PlayerJoinListener.java
@@ -1,0 +1,24 @@
+package net.devvoxel.essentialcore.listeners;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class PlayerJoinListener implements Listener {
+
+    private final EssentialCore plugin;
+
+    public PlayerJoinListener(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        event.getPlayer().sendMessage(ChatColor.GREEN + "Willkommen auf dem Server, " + event.getPlayer().getName() + "!");
+        if (plugin.getSpawn() != null && !event.getPlayer().hasPlayedBefore()) {
+            event.getPlayer().teleport(plugin.getSpawn());
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,17 @@
+name: EssentialCore
+main: net.devvoxel.essentialcore.EssentialCore
+version: 1.0.0
+api-version: 1.21
+commands:
+  heal:
+    description: Heal the player
+  feed:
+    description: Feed the player
+  sethome:
+    description: Set home location
+  home:
+    description: Teleport to home
+  setspawn:
+    description: Set the server spawn location
+  spawn:
+    description: Teleport to server spawn


### PR DESCRIPTION
## Summary
- restructure plugin with `commands` and `listeners` packages
- add `setspawn` and `spawn` commands and move existing commands to their own classes
- implement a simple join listener
- update plugin.yml and README with new commands

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fffca44ec832e927d4b2b6cb41296