### PR TITLE
Fix build by adding Spigot API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,22 @@
     <name>EssentialCore</name>
     <description>Minimal Essentials-like plugin</description>
 
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
## Summary
- add Spigot repository and API dependency so the plugin compiles

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700482d580832e8e9140a1b6228601