### PR TITLE
Add help command and balance aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,40 @@ EssentialCore erweitert die Grundfunktionen von [EssentialsX](https://essentials
 - `/home` – teleportiert dich zu deinem Zuhause
 - `/setspawn` – legt den globalen Spawnpunkt fest
 - `/spawn` – teleportiert zum Spawnpunkt
+- `/afk` – schaltet deinen AFK-Status um
+- `/fly` – erlaubt das Fliegen
+- `/day` – stellt die Tageszeit auf Tag
+- `/night` – stellt die Tageszeit auf Nacht
+- `/gamemode` – wechselt deinen Spielmodus
+- `/god` – schaltet Unverwundbarkeit um
+- `/help` – zeigt eine Liste aller Befehle
+- `/balance [Spieler]` (Alias: `bal`, `ebal`, `ebalance`, `money`, `emoney`) – zeigt dein oder das Guthaben eines anderen Spielers
+- `/pay` – sende Geld an andere Spieler
+- `/setmoney` – setze das Guthaben eines Spielers (Admin)
+
+Neue Spieler starten mit 100 Coins. Alle Kontostände werden in `balances.yml`
+gespeichert und bleiben somit nach Server-Neustarts erhalten.
 
 Das Plugin nutzt eine klare Ordnerstruktur mit `commands` und `listeners`, sodass du es leicht erweitern kannst.
+
+## Berechtigungen
+
+| Befehl   | Permission            |
+|----------|----------------------|
+| `/heal`  | `essentialcore.heal` |
+| `/feed`  | `essentialcore.feed` |
+| `/sethome` | `essentialcore.sethome` |
+| `/home`  | `essentialcore.home` |
+| `/setspawn` | `essentialcore.setspawn` |
+| `/spawn` | `essentialcore.spawn` |
+| `/afk`   | `essentialcore.afk`  |
+| `/fly`   | `essentialcore.fly`  |
+| `/day`   | `essentialcore.day`  |
+| `/night` | `essentialcore.night` |
+| `/gamemode` | `essentialcore.gamemode` |
+| `/god`   | `essentialcore.god`  |
+| `/help` | `essentialcore.help` |
+| `/balance` | `essentialcore.balance` |
+| `/balance [Spieler]` | `essentialcore.balance.other` |
+| `/pay`  | `essentialcore.pay` |
+| `/setmoney` | `essentialcore.setmoney` |

--- a/src/main/java/net/devvoxel/essentialcore/EssentialCore.java
+++ b/src/main/java/net/devvoxel/essentialcore/EssentialCore.java
@@ -1,6 +1,7 @@
 package net.devvoxel.essentialcore;
 
 import net.devvoxel.essentialcore.commands.*;
+import net.devvoxel.essentialcore.economy.MoneyManager;
 import net.devvoxel.essentialcore.listeners.PlayerJoinListener;
 import org.bukkit.Location;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,6 +14,7 @@ public class EssentialCore extends JavaPlugin {
 
     private final Map<UUID, Location> homes = new HashMap<>();
     private Location spawn;
+    private MoneyManager moneyManager;
 
     public Map<UUID, Location> getHomes() {
         return homes;
@@ -26,9 +28,15 @@ public class EssentialCore extends JavaPlugin {
         this.spawn = spawn;
     }
 
+    public MoneyManager getMoneyManager() {
+        return moneyManager;
+    }
+
     @Override
     public void onEnable() {
         getLogger().info("EssentialCore enabled!");
+
+        moneyManager = new MoneyManager(getDataFolder());
 
         // register commands
         getCommand("heal").setExecutor(new HealCommand());
@@ -37,6 +45,16 @@ public class EssentialCore extends JavaPlugin {
         getCommand("home").setExecutor(new HomeCommand(this));
         getCommand("setspawn").setExecutor(new SetSpawnCommand(this));
         getCommand("spawn").setExecutor(new SpawnCommand(this));
+        getCommand("afk").setExecutor(new AfkCommand());
+        getCommand("fly").setExecutor(new FlyCommand());
+        getCommand("day").setExecutor(new DayCommand());
+        getCommand("night").setExecutor(new NightCommand());
+        getCommand("gamemode").setExecutor(new GamemodeCommand());
+        getCommand("god").setExecutor(new GodCommand());
+        getCommand("help").setExecutor(new HelpCommand(this));
+        getCommand("balance").setExecutor(new BalanceCommand(this));
+        getCommand("pay").setExecutor(new PayCommand(this));
+        getCommand("setmoney").setExecutor(new SetMoneyCommand(this));
 
         // register listeners
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(this), this);
@@ -44,6 +62,9 @@ public class EssentialCore extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        if (moneyManager != null) {
+            moneyManager.saveBalances();
+        }
         getLogger().info("EssentialCore disabled!");
     }
 }

--- a/src/main/java/net/devvoxel/essentialcore/commands/AfkCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/AfkCommand.java
@@ -1,0 +1,34 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class AfkCommand implements CommandExecutor {
+    private static final Set<UUID> afkPlayers = new HashSet<>();
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        UUID id = player.getUniqueId();
+        if (afkPlayers.contains(id)) {
+            afkPlayers.remove(id);
+            Bukkit.broadcastMessage(ChatColor.YELLOW + player.getName() + " is no longer AFK.");
+        } else {
+            afkPlayers.add(id);
+            Bukkit.broadcastMessage(ChatColor.YELLOW + player.getName() + " is now AFK.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/BalanceCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/BalanceCommand.java
@@ -1,0 +1,41 @@
+package net.devvoxel.essentialcore.commands;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class BalanceCommand implements CommandExecutor {
+    private final EssentialCore plugin;
+
+    public BalanceCommand(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 1) {
+            if (!sender.hasPermission("essentialcore.balance.other")) {
+                sender.sendMessage(ChatColor.RED + "No permission.");
+                return true;
+            }
+            OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
+            double bal = plugin.getMoneyManager().getBalance(target.getUniqueId());
+            sender.sendMessage(ChatColor.GOLD + target.getName() + " Balance: " + ChatColor.YELLOW + bal);
+            return true;
+        }
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        double balance = plugin.getMoneyManager().getBalance(player.getUniqueId());
+        player.sendMessage(ChatColor.GOLD + "Balance: " + ChatColor.YELLOW + balance);
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/DayCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/DayCommand.java
@@ -1,0 +1,24 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class DayCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        World world;
+        if (sender instanceof Player) {
+            world = ((Player) sender).getWorld();
+        } else {
+            world = Bukkit.getWorlds().get(0);
+        }
+        world.setTime(1000);
+        sender.sendMessage(ChatColor.YELLOW + "Time set to day.");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/FlyCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/FlyCommand.java
@@ -1,0 +1,23 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class FlyCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        boolean enable = !player.getAllowFlight();
+        player.setAllowFlight(enable);
+        player.setFlying(enable);
+        player.sendMessage(ChatColor.GREEN + "Fly " + (enable ? "enabled" : "disabled") + ".");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/GamemodeCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/GamemodeCommand.java
@@ -1,0 +1,30 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class GamemodeCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        GameMode targetMode = player.getGameMode() == GameMode.SURVIVAL ? GameMode.CREATIVE : GameMode.SURVIVAL;
+        if (args.length > 0) {
+            if (args[0].equalsIgnoreCase("survival")) {
+                targetMode = GameMode.SURVIVAL;
+            } else if (args[0].equalsIgnoreCase("creative")) {
+                targetMode = GameMode.CREATIVE;
+            }
+        }
+        player.setGameMode(targetMode);
+        player.sendMessage(ChatColor.GREEN + "Gamemode set to " + targetMode.name().toLowerCase() + ".");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/GodCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/GodCommand.java
@@ -1,0 +1,22 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class GodCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        Player player = (Player) sender;
+        boolean enable = !player.isInvulnerable();
+        player.setInvulnerable(enable);
+        player.sendMessage(ChatColor.YELLOW + "God mode " + (enable ? "enabled" : "disabled") + ".");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/HelpCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/HelpCommand.java
@@ -1,0 +1,24 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class HelpCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+
+    public HelpCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        sender.sendMessage(ChatColor.GOLD + "Available commands:");
+        for (String cmd : plugin.getDescription().getCommands().keySet()) {
+            sender.sendMessage(ChatColor.YELLOW + "/" + cmd);
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/NightCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/NightCommand.java
@@ -1,0 +1,24 @@
+package net.devvoxel.essentialcore.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class NightCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        World world;
+        if (sender instanceof Player) {
+            world = ((Player) sender).getWorld();
+        } else {
+            world = Bukkit.getWorlds().get(0);
+        }
+        world.setTime(13000);
+        sender.sendMessage(ChatColor.YELLOW + "Time set to night.");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/PayCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/PayCommand.java
@@ -1,0 +1,54 @@
+package net.devvoxel.essentialcore.commands;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class PayCommand implements CommandExecutor {
+    private final EssentialCore plugin;
+
+    public PayCommand(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be used by players.");
+            return true;
+        }
+        if (args.length != 2) {
+            sender.sendMessage(ChatColor.RED + "Usage: /pay <player> <amount>");
+            return true;
+        }
+        Player payer = (Player) sender;
+        Player target = Bukkit.getPlayerExact(args[0]);
+        if (target == null) {
+            payer.sendMessage(ChatColor.RED + "Player not found.");
+            return true;
+        }
+        double amount;
+        try {
+            amount = Double.parseDouble(args[1]);
+        } catch (NumberFormatException e) {
+            payer.sendMessage(ChatColor.RED + "Invalid amount.");
+            return true;
+        }
+        if (amount <= 0) {
+            payer.sendMessage(ChatColor.RED + "Amount must be positive.");
+            return true;
+        }
+        if (!plugin.getMoneyManager().withdraw(payer.getUniqueId(), amount)) {
+            payer.sendMessage(ChatColor.RED + "You don't have enough money.");
+            return true;
+        }
+        plugin.getMoneyManager().deposit(target.getUniqueId(), amount);
+        payer.sendMessage(ChatColor.GREEN + "Paid " + amount + " to " + target.getName() + ".");
+        target.sendMessage(ChatColor.GOLD + payer.getName() + " paid you " + amount + ".");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/commands/SetMoneyCommand.java
+++ b/src/main/java/net/devvoxel/essentialcore/commands/SetMoneyCommand.java
@@ -1,0 +1,46 @@
+package net.devvoxel.essentialcore.commands;
+
+import net.devvoxel.essentialcore.EssentialCore;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class SetMoneyCommand implements CommandExecutor {
+    private final EssentialCore plugin;
+
+    public SetMoneyCommand(EssentialCore plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("essentialcore.setmoney")) {
+            sender.sendMessage(ChatColor.RED + "No permission.");
+            return true;
+        }
+        if (args.length != 2) {
+            sender.sendMessage(ChatColor.RED + "Usage: /setmoney <player> <amount>");
+            return true;
+        }
+        Player target = Bukkit.getPlayerExact(args[0]);
+        if (target == null) {
+            sender.sendMessage(ChatColor.RED + "Player not found.");
+            return true;
+        }
+        double amount;
+        try {
+            amount = Double.parseDouble(args[1]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "Invalid amount.");
+            return true;
+        }
+        if (amount < 0) amount = 0;
+        plugin.getMoneyManager().setBalance(target.getUniqueId(), amount);
+        sender.sendMessage(ChatColor.GREEN + "Set " + target.getName() + "'s balance to " + amount + ".");
+        target.sendMessage(ChatColor.GOLD + "Your balance was set to " + amount + ".");
+        return true;
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/economy/MoneyManager.java
+++ b/src/main/java/net/devvoxel/essentialcore/economy/MoneyManager.java
@@ -1,0 +1,71 @@
+package net.devvoxel.essentialcore.economy;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class MoneyManager {
+    public static final double DEFAULT_BALANCE = 100.0;
+
+    private final File file;
+    private final Map<UUID, Double> balances = new HashMap<>();
+    private final YamlConfiguration data;
+
+    public MoneyManager(File dataFolder) {
+        this.file = new File(dataFolder, "balances.yml");
+        if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            try {
+                file.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        this.data = YamlConfiguration.loadConfiguration(file);
+        for (String key : data.getKeys(false)) {
+            try {
+                UUID id = UUID.fromString(key);
+                balances.put(id, data.getDouble(key));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    public double getBalance(UUID id) {
+        return balances.getOrDefault(id, 0.0);
+    }
+
+    public void setBalance(UUID id, double amount) {
+        balances.put(id, Math.max(0.0, amount));
+    }
+
+    public boolean withdraw(UUID id, double amount) {
+        if (amount < 0) return false;
+        double current = getBalance(id);
+        if (current < amount) {
+            return false;
+        }
+        setBalance(id, current - amount);
+        return true;
+    }
+
+    public void deposit(UUID id, double amount) {
+        if (amount < 0) return;
+        setBalance(id, getBalance(id) + amount);
+    }
+
+    public void saveBalances() {
+        for (Map.Entry<UUID, Double> entry : balances.entrySet()) {
+            data.set(entry.getKey().toString(), entry.getValue());
+        }
+        try {
+            data.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/net/devvoxel/essentialcore/listeners/PlayerJoinListener.java
+++ b/src/main/java/net/devvoxel/essentialcore/listeners/PlayerJoinListener.java
@@ -1,6 +1,7 @@
 package net.devvoxel.essentialcore.listeners;
 
 import net.devvoxel.essentialcore.EssentialCore;
+import net.devvoxel.essentialcore.economy.MoneyManager;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -17,8 +18,12 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         event.getPlayer().sendMessage(ChatColor.GREEN + "Willkommen auf dem Server, " + event.getPlayer().getName() + "!");
-        if (plugin.getSpawn() != null && !event.getPlayer().hasPlayedBefore()) {
-            event.getPlayer().teleport(plugin.getSpawn());
+        if (!event.getPlayer().hasPlayedBefore()) {
+            plugin.getMoneyManager().setBalance(event.getPlayer().getUniqueId(),
+                    MoneyManager.DEFAULT_BALANCE);
+            if (plugin.getSpawn() != null) {
+                event.getPlayer().teleport(plugin.getSpawn());
+            }
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,3 +15,77 @@ commands:
     description: Set the server spawn location
   spawn:
     description: Teleport to server spawn
+  afk:
+    description: Toggle AFK status
+  fly:
+    description: Toggle flying
+  day:
+    description: Set the world time to day
+  night:
+    description: Set the world time to night
+  gamemode:
+    description: Toggle or set your gamemode
+  god:
+    description: Toggle invulnerability
+  help:
+    description: List available commands
+    aliases: [ehelp]
+  balance:
+    description: Show your balance
+    aliases: [bal, ebal, ebalance, money, emoney]
+  pay:
+    description: Pay another player
+  setmoney:
+    description: Set a player's balance
+permissions:
+  essentialcore.heal:
+    description: Use /heal
+    default: op
+  essentialcore.feed:
+    description: Use /feed
+    default: op
+  essentialcore.sethome:
+    description: Use /sethome
+    default: true
+  essentialcore.home:
+    description: Use /home
+    default: true
+  essentialcore.setspawn:
+    description: Use /setspawn
+    default: op
+  essentialcore.spawn:
+    description: Use /spawn
+    default: true
+  essentialcore.afk:
+    description: Use /afk
+    default: true
+  essentialcore.fly:
+    description: Use /fly
+    default: op
+  essentialcore.day:
+    description: Use /day
+    default: op
+  essentialcore.night:
+    description: Use /night
+    default: op
+  essentialcore.gamemode:
+    description: Use /gamemode
+    default: op
+  essentialcore.god:
+    description: Use /god
+    default: op
+  essentialcore.help:
+    description: Use /help
+    default: true
+  essentialcore.balance:
+    description: Use /balance
+    default: true
+  essentialcore.balance.other:
+    description: View another player's balance
+    default: op
+  essentialcore.pay:
+    description: Use /pay
+    default: true
+  essentialcore.setmoney:
+    description: Use /setmoney
+    default: op


### PR DESCRIPTION
## Summary
- add `/help` command listing all commands
- give `/help` the alias `ehelp`
- add aliases for `/balance` to match EssentialsX
- document commands and permissions

## Testing
- `mvn -q package` *(fails: command not found)*
- `javac @sources.txt` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_687006fec088832e82cb8fd4b91ffabb